### PR TITLE
module from C++ code not having pybind11 or cppimport directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Note: I have no involvement in the pybind11 project. This is an independent work
 ## Build & Run
 
 - Create and enable a venv
+    - `python -m venv my_env_name`
+    - `source my_env_name/bin/activate`
+    - `python3 -m pip install -r requirements.txt`
+    - `deactivate` # to end your session in this venv
 - Install the project requirements from requirements.txt
 - For all directories except `e07_setup_py`:
     - cd to the directory

--- a/e08_multiple_files/example.cpp
+++ b/e08_multiple_files/example.cpp
@@ -1,0 +1,24 @@
+// An example that uses C++ code in a separate file.
+#include "hello.h"
+
+// Header required for pybind11
+#include <pybind11/pybind11.h>
+
+// Steps to expose the above function to Python
+// Module will be named "example"
+PYBIND11_MODULE(example, m) {
+    m.doc() = "An example module with a simple function to print hello world";
+
+    m.def("hello", &hello, "Print hello world");
+}
+
+// Following is used by cppimport to convert the C++ source to a module.
+// Code inside <% %> is python.
+// The #if guard is optional (added to avoid confusing my editor).
+#if 0
+<%
+cfg['compiler_args'] = ['-std=c++17', '-Wall', '-Wextra']
+cfg['sources'] = ['hello.cpp']
+setup_pybind11(cfg)
+%>
+#endif

--- a/e08_multiple_files/hello.cpp
+++ b/e08_multiple_files/hello.cpp
@@ -1,0 +1,5 @@
+#include <iostream>
+// Function to be called from Python
+void hello() {
+    std::cout << "Hello World" << std::endl;
+}

--- a/e08_multiple_files/hello.h
+++ b/e08_multiple_files/hello.h
@@ -1,0 +1,1 @@
+void hello();

--- a/e08_multiple_files/run_example.py
+++ b/e08_multiple_files/run_example.py
@@ -1,0 +1,10 @@
+import cppimport
+
+# cppimport will build the code and return a module
+example = cppimport.imp("example")
+
+# Try these from python terminal:
+# help(example)
+# help(example.hello)
+
+example.hello()


### PR DESCRIPTION
Your pybind11 examples are terrific.  I'm a big believer in creating minimal examples for instruction.  For your consideration, I've added an 8th example that shows how to make a Python module from code in existing C++ files.  This is useful in cases where the files in question can't be modified to include pybind11 or cppimport directives.
Also made a small addition to the README to clarify the steps needed to make a venv.